### PR TITLE
Fix N+1 queries in user.committees causing slow ActiveStorage downloads

### DIFF
--- a/app/models/concerns/effective_committees_user.rb
+++ b/app/models/concerns/effective_committees_user.rb
@@ -42,7 +42,7 @@ module EffectiveCommitteesUser
   end
 
   def committees
-    committee_members.select { |cm| cm.active? && !cm.marked_for_destruction? }.map { |cm| cm.committee }
+    committee_members.includes(:committee).select { |cm| cm.active? && !cm.marked_for_destruction? }.map { |cm| cm.committee }
   end
 
   # When activity is for sequential uploaded files, group them together like: "12 files were added to Board of Directors - April 2025 Meeting"


### PR DESCRIPTION
Eager load the committee association when building the committees list. Without this, each committee_member triggers a separate query to load its committee, causing file download authorization to take up to 10 seconds for users with many memberships.