### PR TITLE
Fix committee show page to display only root-level folders and match styling

### DIFF
--- a/app/models/effective/committee_folder.rb
+++ b/app/models/effective/committee_folder.rb
@@ -32,6 +32,7 @@ module Effective
 
     scope :deep, -> { includes(:rich_text_body, :committee, :committee_files) }
     scope :sorted, -> { order(:position) }
+    scope :top_level, -> { where(committee_folder_id: nil) }
 
     validates :title, presence: true, length: { maximum: 250 },
       uniqueness: { scope: [:committee_id], message: 'already exists for this committee'}

--- a/app/views/effective/committee_folders/_committee_folder.html.haml
+++ b/app/views/effective/committee_folders/_committee_folder.html.haml
@@ -23,10 +23,9 @@
     - if committee_folder.committee_folders.present?
       %h3 Folders
       .card
-        .card-body
-          %ul
-            - committee_folder.committee_folders.each do |committee_folder|
-              %li= link_to(committee_folder.title, effective_committees.committee_committee_folder_path(committee, committee_folder))
+        .list-group.list-group-flush
+          - committee_folder.committee_folders.each do |committee_folder|
+            = link_to(committee_folder.title, effective_committees.committee_committee_folder_path(committee, committee_folder), class: 'list-group-item list-group-action')
 
     %h3 Files
     .card

--- a/app/views/effective/committees/_committee.html.haml
+++ b/app/views/effective/committees/_committee.html.haml
@@ -20,7 +20,7 @@
         .card
           .list-group.list-group-flush
             - if committee.committee_folders.present?
-              - committee.children.each do |committee_folder|
+              - committee.committee_folders.top_level.each do |committee_folder|
                 = link_to(committee_folder.to_s, effective_committees.committee_committee_folder_path(committee, committee_folder), class: 'list-group-item list-group-action')
             - else
               .list-group-item No files or folders.


### PR DESCRIPTION
## Summary
- Fix committee show page to display only root-level folders instead of all nested folders
- Fix committee folders show page subfolder styling to match the committees show page (Bootstrap list-group-flush instead of plain ul/li)

## Test plan
- [x] Visit a committee show page and confirm only root-level folders are listed
- [x] Visit a committee folder show page with subfolders and confirm they render as Bootstrap list-group items (clickable full-width rows) matching the committees show page style

🤖 Generated with [Claude Code](https://claude.com/claude-code)