### PR TITLE
Add position sorting for committee members

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    effective_committees (0.7.5)
+    effective_committees (0.8.0)
       effective_bootstrap
       effective_datatables (>= 4.0.0)
       effective_resources

--- a/app/datatables/admin/effective_committee_members_datatable.rb
+++ b/app/datatables/admin/effective_committee_members_datatable.rb
@@ -1,10 +1,12 @@
 module Admin
   class EffectiveCommitteeMembersDatatable < Effective::Datatable
     datatable do
+      reorder :position if attributes[:committee]
       length 100
 
       col :id, visible: false
       col :user_id, visible: false
+      col :position, visible: false
 
       col :committee
       col :user

--- a/app/datatables/admin/effective_committees_datatable.rb
+++ b/app/datatables/admin/effective_committees_datatable.rb
@@ -18,7 +18,7 @@ module Admin
       col :display_on_dashboard
 
       col(:committee_members, label: committee_members_label, visible: false) do |committee|
-        committee.committee_members.select(&:active?).sort_by(&:to_s).map do |member|
+        committee.committee_members.select(&:active?).map do |member|
           content_tag(:div, class: 'col-resource_item') do
             label = link_to(member.to_s, "/admin/users/#{member.user_id}/edit")
             badge = badge(member.category) if member.category.present?

--- a/app/models/effective/committee_member.rb
+++ b/app/models/effective/committee_member.rb
@@ -23,10 +23,12 @@ module Effective
       start_on      :date
       end_on        :date
 
+      position      :integer
+
       timestamps
     end
 
-    scope :sorted, -> { order(:id) }
+    scope :sorted, -> { order(:position) }
     scope :deep, -> { includes(:user, :committee) }
 
     before_validation(if: -> { user_ids.present? }) do
@@ -39,18 +41,25 @@ module Effective
 
     after_commit(if: -> { user_ids.present? }) do
       additional = (user_ids - CommitteeMember.where(committee_id: committee_id, user_id: user_ids).pluck(:user_id))
-      additional = additional.map { |user_id| {committee_id: committee_id, committee_type: committee_type, user_id: user_id, user_type: user_type, roles_mask: roles_mask, start_on: start_on, end_on: end_on} }
+      max_position = CommitteeMember.where(committee_id: committee_id, committee_type: committee_type).maximum(:position) || -1
+      additional = additional.each_with_index.map { |user_id, index| {committee_id: committee_id, committee_type: committee_type, user_id: user_id, user_type: user_type, roles_mask: roles_mask, start_on: start_on, end_on: end_on, position: max_position + index + 1} }
       CommitteeMember.insert_all(additional)
     end
 
     after_commit(if: -> { committee_ids.present? }) do
       additional = (committee_ids - CommitteeMember.where(user_id: user_id, committee_id: committee_ids).pluck(:committee_id))
-      additional = additional.map { |committee_id| {committee_id: committee_id, committee_type: committee_type, user_id: user_id, user_type: user_type, roles_mask: roles_mask, start_on: start_on, end_on: end_on} }
+      max_positions = CommitteeMember.where(committee_id: additional, committee_type: committee_type).group(:committee_id).maximum(:position)
+      additional = additional.map { |committee_id| {committee_id: committee_id, committee_type: committee_type, user_id: user_id, user_type: user_type, roles_mask: roles_mask, start_on: start_on, end_on: end_on, position: (max_positions[committee_id] || -1) + 1} }
       CommitteeMember.insert_all(additional)
+    end
+
+    before_validation do
+      self.position ||= (self.class.where(committee_id: committee_id, committee_type: committee_type).maximum(:position) || -1) + 1
     end
 
     validates :committee, presence: true
     validates :user, presence: true
+    validates :position, presence: true
 
     validates :user_id, if: -> { user_id && user_type && committee_id && committee_type },
       uniqueness: { scope: [:committee_id, :committee_type], message: 'already belongs to this committee' }

--- a/app/views/effective/committees/_committee.html.haml
+++ b/app/views/effective/committees/_committee.html.haml
@@ -28,7 +28,7 @@
       .col-lg
         %h3= committee_members_label
 
-        - members = committee.committee_members.select(&:active?).sort_by(&:to_s)
+        - members = committee.committee_members.select(&:active?)
 
         %ul
           - members.each do |member|

--- a/db/migrate/101_create_effective_committees.rb
+++ b/db/migrate/101_create_effective_committees.rb
@@ -34,6 +34,8 @@ class CreateEffectiveCommittees < ActiveRecord::Migration[6.0]
       t.date :start_on
       t.date :end_on
 
+      t.integer :position
+
       t.datetime :updated_at
       t.datetime :created_at
     end

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -85,6 +85,7 @@ ActiveRecord::Schema[8.1].define(version: 101) do
     t.string "committee_type"
     t.datetime "created_at", precision: nil
     t.date "end_on"
+    t.integer "position"
     t.integer "roles_mask"
     t.date "start_on"
     t.datetime "updated_at", precision: nil


### PR DESCRIPTION
## Summary
- Add `position` column to `committee_members` table for per-committee ordering
- Enable drag-and-drop reorder on the admin committee edit page's members tab
- Display members in position order (instead of alphabetical) across all views
- Auto-assign position on creation; include position in bulk insert operations

## Test plan
- [ ] Run migration and verify `position` column is added to `committee_members`
- [ ] Verify admin committee edit page shows drag-and-drop reorder handles on members tab
- [ ] Verify global admin committee members datatable does NOT show reorder handles
- [ ] Confirm committee show page displays members in position order
- [ ] Test bulk member creation assigns incrementing positions

🤖 Generated with [Claude Code](https://claude.com/claude-code)