### PR TITLE
Automatically assign committee_file.title

### DIFF
--- a/app/datatables/effective_committees_datatable.rb
+++ b/app/datatables/effective_committees_datatable.rb
@@ -23,18 +23,6 @@ class EffectiveCommitteesDatatable < Effective::Datatable
       pluralize(committee.committee_members.select(&:active?).length, committee_member_label.downcase)
     end
 
-    col :committee_folders, label: 'Folders'
-
-    col :committee_folders_count, as: :string, label: 'Folders', visible: false do |committee|
-      pluralize(committee.committee_folders_count, 'folders')
-    end
-
-    col :committee_files, label: 'Files', visible: false
-
-    col :committee_files_count, as: :string, label: 'Files' do |committee|
-      pluralize(committee.committee_files_count, 'files')
-    end
-
     actions_col
   end
 

--- a/app/models/effective/committee_file.rb
+++ b/app/models/effective/committee_file.rb
@@ -29,6 +29,7 @@ module Effective
     end
 
     before_validation(if: -> { file.attached? }) do
+      self.title = file.attachment.blob.filename.to_s if title.blank?
       assign_attributes(file_id: file.attachment.blob.id, file_created_at: file.attachment.blob.created_at)
     end
 


### PR DESCRIPTION
## Summary
- Auto-populate `CommitteeFile#title` from the uploaded filename when no title is provided
- Remove unused folder/file columns from the committees datatable

## Test plan
- [ ] Upload a file without setting a title — verify title is set to the filename
- [ ] Upload a file with an explicit title — verify the explicit title is preserved
- [ ] Edit an existing file's title — verify it can be changed freely

🤖 Generated with [Claude Code](https://claude.com/claude-code)