### PR TITLE
Fix NotNullViolation on committee file bulk upload

### DIFF
--- a/app/models/effective/committee_file.rb
+++ b/app/models/effective/committee_file.rb
@@ -37,8 +37,8 @@ module Effective
       errors.add(:title, 'must end with a file extension') unless title.include?('.')
     end
 
-    before_save(if: -> { title.present? && file.attached? }) do
-      file.update(filename: title)
+    after_save(if: -> { title.present? && file.attached? }) do
+      file.blob.update!(filename: title) if file.blob.filename.to_s != title
     end
 
     scope :deep, -> { with_attached_file.includes(:committee, :committee_folder) }


### PR DESCRIPTION
## Summary
- Fix `ActiveRecord::NotNullViolation` (null `record_id` in `active_storage_attachments`) when bulk uploading committee files
- Changed `before_save` to `after_save` so the record has an ID before updating the attachment
- Update blob filename directly via `file.blob.update!` instead of `file.update` to avoid re-saving the attachment
- Added guard to skip unnecessary updates when filename already matches title

## Context
AppSignal incident #2028. The `before_save` callback called `file.update(filename: title)` which triggered an Active Storage attachment save before the `CommitteeFile` record had been persisted, resulting in a null `record_id`.

## Test plan
- [ ] Bulk upload files to a committee folder — files should be created without error
- [ ] Rename a committee file title — blob filename should update to match

🤖 Generated with [Claude Code](https://claude.com/claude-code)